### PR TITLE
Fix NotificationHub::createRegistrationId()

### DIFF
--- a/src/NotificationHubsRest/NotificationHub/NotificationHub.php
+++ b/src/NotificationHubsRest/NotificationHub/NotificationHub.php
@@ -185,15 +185,16 @@ class NotificationHub
     {
         $registration = new GcmRegistration();
         // build uri
-        $uri = $this->endpoint . $this->hubPath . "/registrationIDs/" . self::API_VERSION;
+        $uri = $this->endpoint . $this->hubPath . "/registrationIDs/";
 
         $token = $this->generateSasToken($uri);
         $headers = array_merge(array('Authorization: ' . $token), $registration->getHeaders());
+        $headers = array_merge(array('Content-length: 0'), $headers);
 
-        $response = $this->request(self::METHOD_GET, $uri, $headers, null, true);
+        $response = $this->request(self::METHOD_POST, $uri . self::API_VERSION, $headers, null, true);
 
         preg_match(
-            '#' . $registration->buildUri($this->endpoint, $this->hubPath) . '(\S+)#',
+            '#' . $uri . '([^?]+)' . preg_quote(self::API_VERSION) .'#',
             $response,
             $matches
         );

--- a/tests/NotificationHubsRest/NotificationHub/NotificationHubTest.php
+++ b/tests/NotificationHubsRest/NotificationHub/NotificationHubTest.php
@@ -285,16 +285,17 @@ class NotificationHubTest extends \PHPUnit_Framework_TestCase
     {
         $this->mock->expects($this->once())
         ->method('request')
-        ->with($this->equalTo('GET'),
+        ->with($this->equalTo('POST'),
                 $this->equalTo('https://buildhub-ns.servicebus.windows.net/myHub/registrationIDs/?api-version=2013-08'),
                 $this->callback(function ($headers) {
                     $content = preg_grep('#^Content-Type: application/atom\+xml;type=entry;charset=utf-8$#', $headers);
                     $version = preg_grep('#^x-ms-version: 2013-08$#', $headers);
                     $auth = preg_grep('#^Authorization#', $headers);
-                    if (!$content || !$version || !$auth) {
+                    $contentLength = preg_grep('#^Content-length#', $headers);
+                    if (!$content || !$version || !$auth || !$contentLength) {
                         return false;
                     }
-                    if (array_diff($headers, $content + $auth + $version)) {
+                    if (array_diff($headers, $content + $auth + $version + $contentLength)) {
                         return false;
                     }
                     return true;
@@ -303,7 +304,7 @@ class NotificationHubTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo(true)
         )
         ->will($this->returnValue('Content-Type: application/atom+xml;type=entry;charset=utf-8
-Content-Location: https://buildhub-ns.servicebus.windows.net/myHub/registrations/2372532420827572008-85883004107185159-4
+Content-Location: https://buildhub-ns.servicebus.windows.net/myHub/registrationIDs/2372532420827572008-85883004107185159-4?api-version=2013-08
 ETag: W/"3"'));
 
         $result = $this->mock->createRegistrationId();


### PR DESCRIPTION
This is based on my tests and on the Java SDK that works:
https://github.com/Azure/azure-notificationhubs-java-backend/blob/master/NotificationHubs/src/com/windowsazure/messaging/NotificationHub.java#L116
