### PR TITLE
Add support for custom payload data in Apple notifications

### DIFF
--- a/src/NotificationHubsRest/Notification/AppleNotification.php
+++ b/src/NotificationHubsRest/Notification/AppleNotification.php
@@ -47,7 +47,12 @@ class AppleNotification extends AbstractNotification
      */
     public function getPayload()
     {
+        $customPayloadData = null;
+
         if (!empty($this->options)) {
+            if (!empty($this->options['custom-payload-data']) && is_array($this->options['custom-payload-data'])) {
+                $customPayloadData = $this->options['custom-payload-data'];
+            }
             $payload = array_intersect_key($this->options, array_fill_keys($this->supportedOptions, 0));
         } else {
             $payload = array();
@@ -63,6 +68,10 @@ class AppleNotification extends AbstractNotification
         }
 
         $payload = array('aps' => $payload);
+
+        if (!empty($customPayloadData)) {
+            $payload += $customPayloadData;
+        }
 
         return json_encode($payload);
     }

--- a/tests/NotificationHubsRest/Notification/AppleNotificationTest.php
+++ b/tests/NotificationHubsRest/Notification/AppleNotificationTest.php
@@ -194,6 +194,35 @@ JSON;
         $this->assertJsonStringEqualsJsonString($expected , $payload);
     }
 
+    public function testGetPayloadWithCustomData()
+    {
+        $notification = new AppleNotification(array(
+            'title' => 'Game Request',
+            'body'  => 'Bob wants to play poker',
+        ), array(
+            'content-available' => 1,
+            'custom-payload-data' => array(
+                'id' => '1337',
+                'category' => '1',
+            ),
+        ));
+        $payload = $notification->getPayload();
+
+        $expected = <<<JSON
+{"aps" : {
+  "alert" : {
+    "title" : "Game Request",
+    "body" : "Bob wants to play poker"
+  },
+  "content-available" : 1
+},
+"id": "1337",
+"category": "1"}
+JSON;
+
+        $this->assertJsonStringEqualsJsonString($expected , $payload);
+    }
+
     /**
      * @expectedException \RuntimeException
      */


### PR DESCRIPTION
Cf. https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html
