### PR TITLE
iOS: Silent notifications

### DIFF
--- a/src/NotificationHubsRest/Notification/AppleNotification.php
+++ b/src/NotificationHubsRest/Notification/AppleNotification.php
@@ -60,7 +60,7 @@ class AppleNotification extends AbstractNotification
         }
 
         if (is_array($this->alert)) {
-            if (!empty($alert)) {
+            if (!empty($this->alert)) {
                 $alert = array_intersect_key($this->alert, array_fill_keys($this->supportedAlertProperties, 0));
                 $payload += ['alert' => $alert];
             }

--- a/src/NotificationHubsRest/Notification/AppleNotification.php
+++ b/src/NotificationHubsRest/Notification/AppleNotification.php
@@ -61,7 +61,7 @@ class AppleNotification extends AbstractNotification
 
         if (is_array($this->alert)) {
             if (!empty($alert)) {
-                $alert   = array_intersect_key($this->alert, array_fill_keys($this->supportedAlertProperties, 0));
+                $alert = array_intersect_key($this->alert, array_fill_keys($this->supportedAlertProperties, 0));
                 $payload += ['alert' => $alert];
             }
         } elseif (is_scalar($this->alert)) {

--- a/src/NotificationHubsRest/Notification/AppleNotification.php
+++ b/src/NotificationHubsRest/Notification/AppleNotification.php
@@ -60,8 +60,10 @@ class AppleNotification extends AbstractNotification
         }
 
         if (is_array($this->alert)) {
-            $alert = array_intersect_key($this->alert, array_fill_keys($this->supportedAlertProperties, 0));
-            $payload += ['alert' => $alert];
+            if (!empty($alert)) {
+                $alert   = array_intersect_key($this->alert, array_fill_keys($this->supportedAlertProperties, 0));
+                $payload += ['alert' => $alert];
+            }
         } elseif (is_scalar($this->alert)) {
             $payload += ['alert' => $this->alert];
         } else {


### PR DESCRIPTION
Not sending an `alert` to the server would result in a "silent" notification. Can be useful for notifications that the user shouldn't see.
Read more about silent notifications here: https://stackoverflow.com/a/8949642/560745
Closes https://github.com/webwarejp/notificationhubs-rest-php/issues/20